### PR TITLE
chore: add manual trigger for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   web-docker:
@@ -38,20 +43,13 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           flavor: latest=auto
-          images: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/onboardpi-web
-            ghcr.io/bgunson/onboardpi-web
+          images: ghcr.io/${{ github.repository_owner }}/onboardpi-web
           tags: type=semver,pattern={{version}}
       -
         name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
-        uses: docker/login-action@v2 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - 
         name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -69,8 +67,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm/v7
-          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/onboardpi-web:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/onboardpi-web:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/onboardpi-web:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/onboardpi-web:buildcache,mode=max
 
   obd-docker:
     runs-on: ubuntu-latest
@@ -89,20 +87,13 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           flavor: latest=auto
-          images: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/onboardpi-obd
-            ghcr.io/bgunson/onboardpi-obd
+          images: ghcr.io/${{ github.repository_owner }}/onboardpi-obd
           tags: type=semver,pattern={{version}}
       -
         name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
-        uses: docker/login-action@v2 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - 
         name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -120,5 +111,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm/v7
-          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/onboardpi-obd:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/onboardpi-obd:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/onboardpi-obd:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/onboardpi-obd:buildcache,mode=max


### PR DESCRIPTION
## Summary
- allow manual triggering of build workflow via `workflow_dispatch`

## Testing
- `PYTHONPATH=$PWD pytest` *(fails: KeyError: 'connection')*
- `npm test`